### PR TITLE
Openai

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,18 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	// This dependency is used by the application.
+	implementation 'com.google.guava:guava:31.1-jre'
+
+	// Use Gson to convert Java Objects into their JSON representation
+	implementation 'com.google.code.gson:gson:2.10.1'
+
+	// Use Azure's Content Moderator to reinforce moderation on user input
+	implementation group: 'com.microsoft.azure.cognitiveservices', name: 'azure-cognitiveservices-contentmoderator', version: '1.0.2-beta'
+
+	// This is the community Java SDK for the OpenAI API
+	implementation 'com.theokanning.openai-gpt3-java:service:0.12.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/npcvillagers/npcvillage/controllers/NpcController.java
+++ b/src/main/java/com/npcvillagers/npcvillage/controllers/NpcController.java
@@ -6,6 +6,7 @@ import com.npcvillagers.npcvillage.models.NpcForm;
 import com.npcvillagers.npcvillage.repos.AppUserRepository;
 import com.npcvillagers.npcvillage.repos.NpcRepository;
 import com.npcvillagers.npcvillage.services.NpcFactory;
+import com.npcvillagers.npcvillage.services.OpenAiApiHandler;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -29,6 +30,9 @@ public class NpcController {
 
     @Autowired
     NpcFactory npcFactory;
+
+    @Autowired
+    OpenAiApiHandler openAiApiHandler;
 
     @GetMapping("/create")
     public String getCreateDefault(Model m, Principal p, RedirectAttributes redir) {
@@ -83,6 +87,7 @@ public class NpcController {
     public String createNpc(@ModelAttribute NpcForm npcForm, HttpSession session, RedirectAttributes redir, Principal p) {
         if (p != null) {
             Npc npc = npcFactory.createNpc(npcForm);
+            npc = openAiApiHandler.processNpc(npc);
             npcRepository.save(npc);  // save the npc to the database
             session.setAttribute("npcForm", npcForm);  // add npcForm to the session
 

--- a/src/main/java/com/npcvillagers/npcvillage/services/OpenAiApiHandler.java
+++ b/src/main/java/com/npcvillagers/npcvillage/services/OpenAiApiHandler.java
@@ -1,4 +1,231 @@
 package com.npcvillagers.npcvillage.services;
 
+import com.google.gson.*;
+import com.microsoft.azure.cognitiveservices.vision.contentmoderator.*;
+import com.microsoft.azure.cognitiveservices.vision.contentmoderator.models.*;
+import com.npcvillagers.npcvillage.models.Npc;
+import com.theokanning.openai.service.OpenAiService;
+import com.theokanning.openai.moderation.Moderation;
+import com.theokanning.openai.moderation.ModerationRequest;
+import com.theokanning.openai.completion.chat.ChatCompletionChoice;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import com.theokanning.openai.completion.chat.ChatMessageRole;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
 public class OpenAiApiHandler {
+
+    @Autowired
+    NpcFactory npcFactory;
+
+    private static final String SEED_MESSAGE_SYSTEM = "You are a dungeon master's assistant for their creation of dungeons and dragons NPCs.";
+    private static final String SEED_MESSAGE_USER_PATH = "src/main/resources/static/json/seedUserMessage.json";
+    private static final String SEED_MESSAGE_USER = getSeedUserMessage();
+    private static final String SEED_MESSAGE_ASSISTANT_PATH = "src/main/resources/static/json/seedAssistantMessage.json";
+    private static final String SEED_MESSAGE_ASSISTANT = getSeedAssistantMessage();
+
+    public Npc processNpc(Npc npc) {
+        String userNpcJsonString = npcFactory.toPrettyJsonString(npc);
+
+        long startTime = System.nanoTime();
+
+        // Ensure that the user's inputs comply with OpenAI content policies
+        enforceContentPolicy(userNpcJsonString);
+
+        // Call the OpenAI API and create a JSON format string
+        String generatedNpcJsonString = generateOpenAiChatMessage(userNpcJsonString);
+
+        Npc updatedNpc = npcFactory.updateNpcFromContent(npc, generatedNpcJsonString);
+
+        long endTime = System.nanoTime();
+
+        // Calculate the elapsed time in seconds
+        double elapsedTime = (endTime - startTime) / 1_000_000_000.0;
+        System.out.println("Elapsed time: " + elapsedTime + " seconds");
+
+        return updatedNpc;
+    }
+
+    // We use the OpenAI moderations endpoint and the Azure Content Moderator to ensure what the user typed doesn't break content policy. Based on testing, the OpenAI moderations endpoint is not sufficient on its own in certain edge cases. We use it in concert with the Azure Moderator Client.
+    private void enforceContentPolicy(String userNpcJsonString) {
+        enforceOpenAiContentPolicy(userNpcJsonString);
+        enforceAzureContentPolicy(userNpcJsonString);
+    }
+
+    private void enforceOpenAiContentPolicy(String userNpcJsonString) {
+        String token = System.getenv("OPENAI_TOKEN");
+        if (token == null) {
+            throw new RuntimeException("Error: OPENAI_TOKEN environment variable not set");
+        }
+
+        OpenAiService service = null;
+
+        try {
+            service = new OpenAiService(token);
+
+            ModerationRequest moderationRequest = ModerationRequest.builder()
+                    .input(userNpcJsonString)
+                    .model("text-moderation-latest")
+                    .build();
+
+            List<Moderation> moderationResults = service.createModeration(moderationRequest).getResults();
+
+            // Check if any results were returned
+            if (moderationResults.isEmpty()) {
+                throw new RuntimeException("Error: No moderation results returned");
+            }
+
+            Moderation moderationScore = moderationResults.get(0);
+
+            // Check if the content is flagged by OpenAI
+            if (moderationScore.isFlagged()) {
+                // Throw an exception indicating content policy violation
+                throw new IllegalArgumentException("Content violates the content policy. Please modify your NPC");
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Error enforcing OpenAI content policy", e);
+        } finally {
+            if (service != null) {
+                service.shutdownExecutor();
+            }
+        }
+    }
+
+    private void enforceAzureContentPolicy(String userNpcJsonString) {
+        String azureModeratorEndpoint = System.getenv("AZURE_MODERATOR_ENDPOINT");
+        if (azureModeratorEndpoint == null) {
+            throw new RuntimeException("Error: AZURE_MODERATOR_ENDPOINT environment variable not set");
+        }
+
+        String azureModeratorSubscriptionKey = System.getenv("AZURE_MODERATOR_SUBSCRIPTION_KEY");
+        if (azureModeratorEndpoint == null) {
+            throw new RuntimeException("Error: AZURE_MODERATOR_SUBSCRIPTION_KEY environment variable not set");
+        }
+
+        try {
+            // Create Azure Content Moderator client
+            ContentModeratorClient azureModeratorClient = ContentModeratorManager.authenticate(
+                    AzureRegionBaseUrl.fromString(azureModeratorEndpoint), azureModeratorSubscriptionKey);
+
+            // Detect the language of the text
+            DetectedLanguage detectedLanguage = azureModeratorClient.textModerations().detectLanguage("text/plain", userNpcJsonString.getBytes());
+
+            if (detectedLanguage == null) {
+                throw new RuntimeException("Failed to detect the language of the text");
+            }
+
+            // Screen the text
+            ScreenTextOptionalParameter screenTextOptionalParameter = new ScreenTextOptionalParameter().withLanguage(detectedLanguage.detectedLanguage());
+            Screen screen = azureModeratorClient.textModerations().screenText("text/plain", userNpcJsonString.getBytes(), screenTextOptionalParameter);
+
+            // If there are any matched items in the Auto-detected language, PII or Classification categories.
+            if ((screen.pII() != null) ||
+                    (screen.classification() != null &&
+                            (screen.classification().reviewRecommended()))) {
+                throw new IllegalArgumentException("Content violates the content policy. Please modify your NPC");
+            }
+        } catch (APIErrorException e) {
+            // Handle API exceptions here
+            throw new RuntimeException("An error occurred while screening the content with Azure Content Moderator", e);
+        } catch (Exception e) {
+            // Handle other exceptions here
+            throw new RuntimeException("An unexpected error occurred", e);
+        }
+    }
+
+    private String generateOpenAiChatMessage(String userNpcJsonString) {
+        String token = System.getenv("OPENAI_TOKEN");
+        if (token == null) {
+            throw new RuntimeException("Error: OPENAI_TOKEN environment variable not set");
+        }
+
+        OpenAiService service = null;
+
+        try {
+            // Set duration to 60 seconds to avoid a socket exception for long response times
+            service = new OpenAiService(token, Duration.ofSeconds(60));
+
+            // Seed the chat with system context, example input, and example output, and add the user's Npc to the messages
+            final List<ChatMessage> messages = new ArrayList<>();
+            final ChatMessage systemMessage = new ChatMessage(ChatMessageRole.SYSTEM.value(), SEED_MESSAGE_SYSTEM);
+            final ChatMessage seedUserMessage = new ChatMessage(ChatMessageRole.USER.value(), SEED_MESSAGE_USER);
+            final ChatMessage seedAssistantMessage = new ChatMessage(ChatMessageRole.ASSISTANT.value(), SEED_MESSAGE_ASSISTANT);
+            final ChatMessage userNpcRequestMessage = new ChatMessage(ChatMessageRole.USER.value(), userNpcJsonString);
+            messages.add(systemMessage);
+            messages.add(seedUserMessage);
+            messages.add(seedAssistantMessage);
+            messages.add(userNpcRequestMessage);
+
+            // Send the API request
+            ChatCompletionRequest chatCompletionRequest = ChatCompletionRequest
+                    .builder()
+                    .model("gpt-3.5-turbo")
+                    .messages(messages)
+                    .n(1)
+                    .temperature(0.8)
+                    .maxTokens(1000)
+                    .logitBias(new HashMap<>())
+                    .build();
+
+            // Extract the message content of the response
+            List<ChatCompletionChoice> choices = service.createChatCompletion(chatCompletionRequest).getChoices();
+
+            if (choices.isEmpty()) {
+                throw new RuntimeException("Error: No response from OpenAI");
+            }
+            String content = choices.get(0).getMessage().getContent();
+
+            return content;
+        } catch (Exception e) {
+            throw new RuntimeException("Error generating OpenAI chat message", e);
+        } finally {
+            if (service != null) {
+                service.shutdownExecutor();
+            }
+        }
+    }
+
+    private static String getSeedUserMessage() {
+        String prettyJsonString = getPrettyJsonString(SEED_MESSAGE_USER_PATH);
+        String originalMessage = "Generate a JSON-formatted NPC (Non-Player Character) for use in a Dungeons and Dragons campaign. The JSON should ONLY contain the following fields: \"name\", \"age\", \"voice\", \"occupation\", \"description\", \"personality\", \"motivation\", \"ideal\", \"bond\", \"flaw\", and \"history\". Please ensure that the fields \"ideal\", \"bond\", and \"flaw\" are described from a first-person point of view. IMPORTANT: Do not include any other fields beyond the ones specifically mentioned here, such as species, subspecies, gender, alignment or any other. IMPORTANT: The NPC's \"history\" or \"motivation\" should clearly reflect the given \"playerRelationship\" input, which describes the relationship of the NPC to the players. This relationship should be clearly visible in the NPC's backstory or motivation. IMPORTANT: Do not mis-gender your creation.\n\n";
+        String fullMessage = originalMessage + prettyJsonString;
+
+        return fullMessage;
+    }
+
+    private static String getSeedAssistantMessage() {
+        return getPrettyJsonString(SEED_MESSAGE_ASSISTANT_PATH);
+    }
+
+    private static String getPrettyJsonString(String filePath) {
+        try (FileReader reader = new FileReader(filePath)) {
+            // create a Gson instance with pretty printing
+            Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+            // parse the JSON file into a JsonArray
+            JsonArray jsonArray = JsonParser.parseReader(reader).getAsJsonArray();
+
+            // convert the JsonArray into a pretty printed string
+            String prettyJsonString = gson.toJson(jsonArray);
+
+            // Replace escaped quotes with actual quotes
+            prettyJsonString = prettyJsonString.replace("\\\"", "\"");
+
+            return prettyJsonString;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/com/npcvillagers/npcvillage/utils/CustomEnumTypeAdapter.java
+++ b/src/main/java/com/npcvillagers/npcvillage/utils/CustomEnumTypeAdapter.java
@@ -1,0 +1,55 @@
+package com.npcvillagers.npcvillage.utils;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomEnumTypeAdapter<T extends Enum<T>> extends TypeAdapter<T> {
+
+    private final Class<T> enumClass;
+    private final Map<String, T> displayNameToConstantMap = new HashMap<>();
+
+    public CustomEnumTypeAdapter(Class<T> enumClass) {
+        this.enumClass = enumClass;
+        try {
+            for (T constant : enumClass.getEnumConstants()) {
+                Method getDisplayNameMethod = enumClass.getMethod("getDisplayName");
+                String displayName = (String) getDisplayNameMethod.invoke(constant);
+                displayNameToConstantMap.put(displayName, constant);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void write(JsonWriter out, T value) throws IOException {
+        if (value == null) {
+            out.nullValue();
+        } else {
+            try {
+                Method getDisplayNameMethod = enumClass.getMethod("getDisplayName");
+                String displayName = (String) getDisplayNameMethod.invoke(value);
+                out.value(displayName);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public T read(JsonReader reader) throws IOException {
+        if (reader.peek() == JsonToken.NULL) {
+            reader.nextNull();
+            return null;
+        } else {
+            return displayNameToConstantMap.get(reader.nextString());
+        }
+    }
+}

--- a/src/main/resources/static/json/seedAssistantMessage.json
+++ b/src/main/resources/static/json/seedAssistantMessage.json
@@ -1,0 +1,15 @@
+[
+  {
+    "name": "Sunny Tezrin",
+    "age": "33 years old",
+    "voice": "high pitched, energetic, slight lisp",
+    "occupation": "Adventurer",
+    "appearance": "A towering woman with bronze skin, platinum hair tied in a loose plait, and freckles that glow like sparks. Her eyes are sheets of shining gold, and she wears polished splint armor over a white tunic that ends at her knees. A massive greatsword hangs in a baldric on her back.",
+    "personality": "Sunny is bubbly, cheerful, and gregarious. She is a never-ending font of positivity. However, she is ruthless to those she views as evil. Her ideas of morality are very black and white, and those who tip the scales against righteousness feel her cold wrath.",
+    "motivation": "She wants to protect the world and do good in the Dawnfather's name.",
+    "ideal": "We should all strive to help one another",
+    "bond": "I will gladly lay down my life to protect the people of this realm",
+    "flaw": "I'm the last word in morality. If I think you have done an unforgivable act, I'll end your life with a smile.",
+    "history": "Sunny is the half-celestial daughter of a human man and a deva woman in the service of Pelor. She swore a paladin's oath to Pelor, and came to Haldrim to become a hero as decreed by her mother, Aranareth. She is very close to her mother, and speaks with her often, though there is not always a response. She was given Toot, a hollyphant, as a companion when she stopped a demon invasion of the Northlands. Sunny now acts as a mentor for the players, instructing them on how to navigate Haldrim's web of intrigue and danger."
+  }
+]

--- a/src/main/resources/static/json/seedUserMessage.json
+++ b/src/main/resources/static/json/seedUserMessage.json
@@ -1,0 +1,31 @@
+[
+  {
+    "name": "Any",
+    "species": "Aasimar",
+    "subSpecies": "n/a",
+    "gender": "Female",
+    "alignment": "Lawful Good",
+    "age": "Adult. Generate age in years.",
+    "voice": "Any",
+    "occupation": "Adventurer",
+    "characterClass" : "Paladin",
+    "campaignStyle": "High Fantasy",
+    "themes": [
+      "magic",
+      "wonder",
+      "heroism",
+      "adventure",
+      "mythical creatures",
+      "epic battles",
+      "destiny"
+    ],
+    "playerRelationship": "Mentor",
+    "appearance": "She should carry a greatsword",
+    "personality": "Any",
+    "motivation": "Any",
+    "ideal": "Any",
+    "bond": "Any",
+    "flaw": "Any",
+    "history": "Sunny is the half celestial daughter of a human man and a deva woman in the service of Pelor. She came to Haldrim to become a hero as decreed by her mother, Aranareth. She is very close to her mother, and speaks with her often, though there is not always a response. She was given Toot, a hollyphant, as a companion when she stopped a demon invasion of the Northlands."
+  }
+]

--- a/src/main/resources/templates/fragments/createNpcForm.html
+++ b/src/main/resources/templates/fragments/createNpcForm.html
@@ -84,6 +84,14 @@
             <input type="text" id="customOccupation" name="customOccupation" th:value="${npcForm.customOccupation}">
         </div>
 
+        <label for="characterClass">Character Class</label>
+        <select id="characterClass"  name="characterClass" required>
+            <option th:each="characterClass : ${T(com.npcvillagers.npcvillage.models.enums.CharacterClass).values()}"
+                    th:value="${characterClass.name()}"
+                    th:text="${characterClass.getDisplayName()}"
+                    th:selected="${characterClass.name() == npcForm.characterClass.name()}">Character Class</option>
+        </select>
+
         <label for="appearance">Appearance</label>
         <input type="text" id="appearance" name="appearance" th:value="${npcForm.appearance}" required>
 

--- a/src/main/resources/templates/fragments/editNpcForm.html
+++ b/src/main/resources/templates/fragments/editNpcForm.html
@@ -91,6 +91,15 @@
             <input type="text" id="customOccupation" name="customOccupation" th:value="${npcForm.customOccupation}">
         </div>
 
+        <label for="characterClass">Character Class</label>
+        <select id="characterClass"  name="characterClass" required>
+            <option th:each="characterClass : ${T(com.npcvillagers.npcvillage.models.enums.CharacterClass).values()}"
+                    th:if="${!characterClass.name().startsWith('ANY')}"
+                    th:value="${characterClass.name()}"
+                    th:text="${characterClass.getDisplayName()}"
+                    th:selected="${characterClass.name() == npcForm.characterClass.name()}">Character Class</option>
+        </select>
+
         <label for="appearance">Appearance</label>
         <input type="text" id="appearance" name="appearance" th:value="${npcForm.appearance}" required>
 

--- a/src/main/resources/templates/fragments/npcStatBlock.html
+++ b/src/main/resources/templates/fragments/npcStatBlock.html
@@ -12,7 +12,6 @@
   <p><strong>Gender:</strong> <span th:text="${npc.gender.getDisplayName()}"></span></p>
   <p><strong>Alignment:</strong> <span th:text="${npc.alignment.getDisplayName()}"></span></p>
   <p><strong>Player Relationship:</strong> <span th:text="${npc.playerRelationship.getDisplayName()}"></span></p>
-  <p><strong>Campaign Style:</strong> <span th:text="${npc.campaignStyle.getDisplayName()}"></span></p>
   <p><strong>Voice:</strong> <span th:text="${npc.voice}"></span></p>
   <p><strong>Age:</strong> <span th:text="${npc.age}"></span></p>
   <p><strong>Occupation:</strong> <span th:text="${npc.occupation}"></span></p>


### PR DESCRIPTION
- [X]  Create OpenAiApiHandler service using OpenAIService community library
- [X]  Use gson to deserialize Npc object in NpcFactory with a private, reduced field version called NpcJson
- [X]  Seed messages using json files to feed ChatGPT meta data, example user request, and example GPT response
- [X]  Send message chain to ChatGPT and extract response message content
- [X]  Merge the json response string into the Npc object by serializing both into json and then mapping only the fields gpt gives back
- [X]  Deserialize back into Npc object with gson
- [X]  Update Npc in the route and save to the database
- [X]  Integrate OpenAI moderations endpoint to securely handle user input